### PR TITLE
determine startup state on startup instead of shutdown

### DIFF
--- a/QSPasteboardController.m
+++ b/QSPasteboardController.m
@@ -27,7 +27,7 @@
 		[QSPasteboardController sharedInstance];
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(saveVisibilityState:) name:@"QSEventNotification" object:nil];
-    if([defaults boolForKey:@"QSPasteboardHistoryIsVisible"]){
+    if([defaults boolForKey:@"QSPasteboardHistoryIsVisible"] && ![(QSDockingWindow *)[[self sharedInstance] window] canFade]){
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(showClipboardHidden:) name:@"QSApplicationDidFinishLaunchingNotification" object:nil];
     }  
     
@@ -58,10 +58,7 @@
 // saves the state of the shelf window when Quicksivler goes to quit (used on next QS launch - see +loadPlugIn)
 +(void)saveVisibilityState:(NSNotification *)notif {
     if ([[notif object] isEqualToString:@"QSQuicksilverWillQuitEvent"]) {
-        BOOL visible = ![(QSDockingWindow *)[[self sharedInstance] window] hidden];
-        if (!visible) {
-            visible = [(QSDockingWindow *)[[self sharedInstance] window] canFade];
-        }
+		BOOL visible = ![(QSDockingWindow *)[[self sharedInstance] window] hidden];
         [[NSUserDefaults standardUserDefaults] setBool:visible forKey:@"QSPasteboardHistoryIsVisible"];
     }
 }


### PR DESCRIPTION
The subject sums it up.

I came to this when looking into quicksilver/Quicksilver#691

There are two things we need to know on startup to correctly restore the window, but only one boolean in the preferences. So I’ve modified this to store the one we need and determine the other on startup.

I’m not bumping the version because I don’t intend for this alone to be part of a new release. It sounds like @HenningJ has some bigger changes planned to address quicksilver/Quicksilver#809 so this can just be incorporated into the next release.
