### PR TITLE
load the clipboard history if it's visible OR docked

### DIFF
--- a/QSPasteboardController.m
+++ b/QSPasteboardController.m
@@ -27,7 +27,7 @@
 		[QSPasteboardController sharedInstance];
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(saveVisibilityState:) name:@"QSEventNotification" object:nil];
-    if([defaults boolForKey:@"QSPasteboardHistoryIsVisible"] && ![(QSDockingWindow *)[[self sharedInstance] window] canFade]){
+    if([defaults boolForKey:@"QSPasteboardHistoryIsVisible"] || [(QSDockingWindow *)[[self sharedInstance] window] canFade]){
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(showClipboardHidden:) name:@"QSApplicationDidFinishLaunchingNotification" object:nil];
     }  
     


### PR DESCRIPTION
The window will never be visible _and_ docked, so this check was unnecessary. However, a docked window _does_ need to be loaded into memory on startup in order to respond to mouse events.
