### PR TITLE
don’t instantiate windows prematurely

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -461,5 +461,10 @@
 			<string>Clipboard.icns</string>
 		</dict>
 	</dict>
+	<key>QSRequirements</key>
+	<dict>
+		<key>version</key>
+		<string>3926</string>
+	</dict>
 </dict>
 </plist>

--- a/QSPasteboardController.m
+++ b/QSPasteboardController.m
@@ -47,7 +47,7 @@
 + (void)showClipboardHidden:(id)sender
 {
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-	if ([defaults boolForKey:@"QSPasteboardHistoryIsVisible"] || [(QSDockingWindow *)[[self sharedInstance] window] canFade]) {
+	if ([defaults boolForKey:@"QSPasteboardHistoryIsVisible"] || [(QSDockingWindow *)[[self sharedInstance] window] isDocked]) {
 		[(QSDockingWindow *)[[self sharedInstance] window] orderFrontHidden:sender];
 	}
 }
@@ -429,7 +429,7 @@
 }
 - (IBAction)hideWindow:(id)sender {
 	[[self window] saveFrame];
-  if (![(QSDockingWindow *)[self window] canFade] && [[NSUserDefaults standardUserDefaults] boolForKey:@"QSPasteboardController HideAfterPasting"]) {
+  if (![(QSDockingWindow *)[self window] isDocked] && [[NSUserDefaults standardUserDefaults] boolForKey:@"QSPasteboardController HideAfterPasting"]) {
 		[[self window] orderOut:self];
   } else {
     [(QSDockingWindow *)[self window] hide:self];


### PR DESCRIPTION
My last change was causing docked windows to get instantiated before the handler was available to load icons for the objects in the window. This fixes it.
