### PR TITLE
"Paste on selection" option added

### DIFF
--- a/QSPasteboardController.m
+++ b/QSPasteboardController.m
@@ -222,7 +222,7 @@
 		case QSPasteboardHistoryMode:
 		case QSPasteboardStoreMode:
 			[self copyToClipboard:[self selectedObject]];
-			if([[NSUserDefaults standardUserDefaults] boolForKey:@"Paste on Selection"]) {
+			if([[NSUserDefaults standardUserDefaults] boolForKey:@"QSPasteboard Paste on Selection"]) {
 				QSForcePaste();
 			}
 			break;
@@ -232,7 +232,7 @@
 				id object = (sender?[pasteboardCacheArray objectAtIndex:0] :[self selectedObject]);
 				supressCapture = YES;
 				[self copyToClipboard:object];
-				if([[NSUserDefaults standardUserDefaults] boolForKey:@"Paste on Selection"]) {
+				if([[NSUserDefaults standardUserDefaults] boolForKey:@"QSPasteboard Paste on Selection"]) {
 					QSForcePaste();
 				}
 				if (sender) {
@@ -240,9 +240,7 @@
 					[pasteboardHistoryTable reloadData];
 				}
 			} else {
-				if([[NSUserDefaults standardUserDefaults] boolForKey:@"Beep"]) {
-					NSBeep();
-				}
+				NSBeep();
 			}
 			break;
 		default:

--- a/QSPasteboardController.m
+++ b/QSPasteboardController.m
@@ -240,9 +240,9 @@
 					[pasteboardHistoryTable reloadData];
 				}
 			} else {
-                if([[NSUserDefaults standardUserDefaults] boolForKey:@"Beep"]) {
-                    NSBeep();
-                }
+				if([[NSUserDefaults standardUserDefaults] boolForKey:@"Beep"]) {
+					NSBeep();
+				}
 			}
 			break;
 		default:

--- a/QSPasteboardController.m
+++ b/QSPasteboardController.m
@@ -222,23 +222,27 @@
 		case QSPasteboardHistoryMode:
 		case QSPasteboardStoreMode:
 			[self copyToClipboard:[self selectedObject]];
-			QSForcePaste();
+			if([[NSUserDefaults standardUserDefaults] boolForKey:@"Paste on Selection"]) {
+				QSForcePaste();
+			}
 			break;
 		case QSPasteboardQueueMode:
 		case QSPasteboardStackMode:
 			if ([pasteboardCacheArray count]) {
-
 				id object = (sender?[pasteboardCacheArray objectAtIndex:0] :[self selectedObject]);
 				supressCapture = YES;
-                [self copyToClipboard:object];
-				QSForcePaste();
+				[self copyToClipboard:object];
+				if([[NSUserDefaults standardUserDefaults] boolForKey:@"Paste on Selection"]) {
+					QSForcePaste();
+				}
 				if (sender) {
 					[pasteboardCacheArray removeObjectAtIndex:0];
 					[pasteboardHistoryTable reloadData];
 				}
 			} else {
-				NSBeep();
-
+                if([[NSUserDefaults standardUserDefaults] boolForKey:@"Beep"]) {
+                    NSBeep();
+                }
 			}
 			break;
 		default:

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.5.1</string>
 	<key>CFBundleVersion</key>
-	<string>157</string>
+	<string>159</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2014, QSApp</string>
 	<key>NSPrincipalClass</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -26,7 +26,7 @@
 	<string>QSPasteboardController</string>
 	<key>QSDefaults</key>
 	<dict>
-		<key>Beep</key>
+		<key>QSPasteboard Paste on Selection</key>
 		<false/>
 		<key>Capture Pasteboard History</key>
 		<false/>
@@ -34,8 +34,6 @@
 		<integer>10</integer>
 		<key>Discard Pasteboard History</key>
 		<true/>
-		<key>Paste on Selection</key>
-		<false/>
 		<key>QSPasteboardController HideAfterPasting</key>
 		<false/>
 	</dict>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,19 +19,23 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>144</string>
+	<string>14F</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2014, QSApp</string>
 	<key>NSPrincipalClass</key>
 	<string>QSPasteboardController</string>
 	<key>QSDefaults</key>
 	<dict>
+		<key>Beep</key>
+		<false/>
 		<key>Capture Pasteboard History</key>
 		<false/>
 		<key>Capture Pasteboard History Count</key>
 		<integer>10</integer>
 		<key>Discard Pasteboard History</key>
 		<true/>
+		<key>Paste on Selection</key>
+		<false/>
 		<key>QSPasteboardController HideAfterPasting</key>
 		<false/>
 	</dict>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>14F</string>
+	<string>157</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2014, QSApp</string>
 	<key>NSPrincipalClass</key>

--- a/Resources/QSPasteboardPrefPane.xib
+++ b/Resources/QSPasteboardPrefPane.xib
@@ -23,7 +23,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField hidden="YES" verticalHuggingPriority="750" id="7">
-                        <rect key="frame" x="183" y="20" width="65" height="22"/>
+                        <rect key="frame" x="183" y="16" width="65" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="45">
                             <font key="font" metaFont="system"/>
@@ -73,8 +73,19 @@
                             <binding destination="17" name="value" keyPath="values.QSPasteboardController HideAfterPasting" id="20"/>
                         </connections>
                     </button>
+                    <button toolTip="Hide clipboard automatically after pasting" id="TyO-k8-hDx" userLabel="Paste on selection">
+                        <rect key="frame" x="17" y="187" width="137" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Paste on selection" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="zvX-Sh-Jno">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="smallSystem"/>
+                        </buttonCell>
+                        <connections>
+                            <binding destination="17" name="value" keyPath="values.Paste on Selection" id="vlG-kN-eWb"/>
+                        </connections>
+                    </button>
                     <textField hidden="YES" verticalHuggingPriority="750" id="12">
-                        <rect key="frame" x="17" y="22" width="161" height="17"/>
+                        <rect key="frame" x="17" y="18" width="161" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Ignore items larger than:" id="49">
                             <font key="font" metaFont="system"/>
@@ -92,7 +103,7 @@
                         </textFieldCell>
                     </textField>
                     <button hidden="YES" id="36">
-                        <rect key="frame" x="17" y="45" width="137" height="18"/>
+                        <rect key="frame" x="17" y="36" width="137" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Enable HotKeys" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="51">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -103,7 +114,7 @@
                         </connections>
                     </button>
                     <textField verticalHuggingPriority="750" id="54">
-                        <rect key="frame" x="17" y="182" width="135" height="17"/>
+                        <rect key="frame" x="17" y="154" width="135" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Ignore Applications: " id="55">
                             <font key="font" metaFont="cellTitle"/>
@@ -112,7 +123,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="56">
-                        <rect key="frame" x="18" y="90" width="271" height="28"/>
+                        <rect key="frame" x="18" y="62" width="271" height="28"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" controlSize="mini" sendsActionOnEndEditing="YES" title="Enter the names of applications that you do not want Quicksilver to store clipboard history for." id="57">
                             <font key="font" metaFont="smallSystem"/>
@@ -121,7 +132,7 @@
                         </textFieldCell>
                     </textField>
                     <tokenField verticalHuggingPriority="750" id="82">
-                        <rect key="frame" x="20" y="125" width="256" height="55"/>
+                        <rect key="frame" x="20" y="97" width="256" height="55"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <tokenFieldCell key="cell" selectable="YES" editable="YES" borderStyle="bezel" alignment="left" drawsBackground="YES" allowsEditingTextAttributes="YES" id="83">
                             <font key="font" metaFont="cellTitle"/>
@@ -151,6 +162,17 @@
                                     <string key="NSValueTransformerName">NSNegateBoolean</string>
                                 </dictionary>
                             </binding>
+                        </connections>
+                    </button>
+                    <button toolTip="Paste directly after selecting an item" id="IbY-tZ-Ao7" userLabel="Beep">
+                        <rect key="frame" x="17" y="169" width="137" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Beep on Paste" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="cN2-ot-hfV">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="smallSystem"/>
+                        </buttonCell>
+                        <connections>
+                            <binding destination="17" name="value" keyPath="values.Beep" id="xC4-Rc-pfV"/>
                         </connections>
                     </button>
                 </subviews>

--- a/Resources/QSPasteboardPrefPane.xib
+++ b/Resources/QSPasteboardPrefPane.xib
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="QSPasteboardPrefPane">
@@ -15,15 +16,15 @@
         <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="5" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="157" y="621" width="365" height="311"/>
+            <rect key="contentRect" x="157" y="621" width="365" height="320"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1028"/>
             <value key="minSize" type="size" width="213" height="107"/>
             <view key="contentView" id="6">
-                <rect key="frame" x="0.0" y="0.0" width="365" height="311"/>
+                <rect key="frame" x="0.0" y="0.0" width="365" height="320"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField hidden="YES" verticalHuggingPriority="750" id="7">
-                        <rect key="frame" x="183" y="16" width="65" height="22"/>
+                        <rect key="frame" x="183" y="21" width="65" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="45">
                             <font key="font" metaFont="system"/>
@@ -32,7 +33,7 @@
                         </textFieldCell>
                     </textField>
                     <textField toolTip="Number of items to save" verticalHuggingPriority="750" id="8">
-                        <rect key="frame" x="41" y="250" width="30" height="19"/>
+                        <rect key="frame" x="41" y="259" width="30" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="center" title="10" drawsBackground="YES" id="46">
                             <numberFormatter key="formatter" formatterBehavior="10_0" positiveFormat="#,##0" negativeFormat="-#,##0" localizesFormat="NO" thousandSeparator="," id="10">
@@ -52,7 +53,7 @@
                         </connections>
                     </textField>
                     <button toolTip="Save items copied to the clipboard" id="9">
-                        <rect key="frame" x="17" y="275" width="127" height="18"/>
+                        <rect key="frame" x="17" y="284" width="127" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Capture History:" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="47">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -63,7 +64,7 @@
                         </connections>
                     </button>
                     <button toolTip="Hide clipboard automatically after pasting" id="11">
-                        <rect key="frame" x="17" y="205" width="137" height="18"/>
+                        <rect key="frame" x="17" y="214" width="137" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Hide after pasting" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="48">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -74,7 +75,7 @@
                         </connections>
                     </button>
                     <button toolTip="Hide clipboard automatically after pasting" id="TyO-k8-hDx" userLabel="Paste on selection">
-                        <rect key="frame" x="17" y="187" width="137" height="18"/>
+                        <rect key="frame" x="17" y="196" width="137" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Paste on selection" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="zvX-Sh-Jno">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -85,7 +86,7 @@
                         </connections>
                     </button>
                     <textField hidden="YES" verticalHuggingPriority="750" id="12">
-                        <rect key="frame" x="17" y="18" width="161" height="17"/>
+                        <rect key="frame" x="17" y="25" width="161" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Ignore items larger than:" id="49">
                             <font key="font" metaFont="system"/>
@@ -94,7 +95,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" id="13">
-                        <rect key="frame" x="74" y="252" width="129" height="14"/>
+                        <rect key="frame" x="74" y="262" width="129" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="items" id="50">
                             <font key="font" metaFont="smallSystem"/>
@@ -103,7 +104,7 @@
                         </textFieldCell>
                     </textField>
                     <button hidden="YES" id="36">
-                        <rect key="frame" x="17" y="36" width="137" height="18"/>
+                        <rect key="frame" x="17" y="41" width="137" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Enable HotKeys" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="51">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -114,7 +115,7 @@
                         </connections>
                     </button>
                     <textField verticalHuggingPriority="750" id="54">
-                        <rect key="frame" x="17" y="154" width="135" height="17"/>
+                        <rect key="frame" x="17" y="157" width="135" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Ignore Applications: " id="55">
                             <font key="font" metaFont="cellTitle"/>
@@ -123,7 +124,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="56">
-                        <rect key="frame" x="18" y="62" width="271" height="28"/>
+                        <rect key="frame" x="18" y="65" width="271" height="28"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" controlSize="mini" sendsActionOnEndEditing="YES" title="Enter the names of applications that you do not want Quicksilver to store clipboard history for." id="57">
                             <font key="font" metaFont="smallSystem"/>
@@ -132,7 +133,7 @@
                         </textFieldCell>
                     </textField>
                     <tokenField verticalHuggingPriority="750" id="82">
-                        <rect key="frame" x="20" y="97" width="256" height="55"/>
+                        <rect key="frame" x="20" y="100" width="256" height="55"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <tokenFieldCell key="cell" selectable="YES" editable="YES" borderStyle="bezel" alignment="left" drawsBackground="YES" allowsEditingTextAttributes="YES" id="83">
                             <font key="font" metaFont="cellTitle"/>
@@ -149,7 +150,7 @@
                         </connections>
                     </tokenField>
                     <button toolTip="Clipboard history will be stored unencrypted on disk. Not recommended if you will ever copy sensitive data." id="SAG-k3-XDG">
-                        <rect key="frame" x="38" y="225" width="309" height="20"/>
+                        <rect key="frame" x="38" y="234" width="309" height="20"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Keep history when restarting (insecure)" bezelStyle="regularSquare" imagePosition="left" controlSize="small" inset="2" id="ST0-2s-72e">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -165,7 +166,7 @@
                         </connections>
                     </button>
                     <button toolTip="Paste directly after selecting an item" id="IbY-tZ-Ao7" userLabel="Beep">
-                        <rect key="frame" x="17" y="169" width="137" height="18"/>
+                        <rect key="frame" x="17" y="178" width="137" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Beep on Paste" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="cN2-ot-hfV">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>

--- a/Resources/QSPasteboardPrefPane.xib
+++ b/Resources/QSPasteboardPrefPane.xib
@@ -74,7 +74,7 @@
                             <binding destination="17" name="value" keyPath="values.QSPasteboardController HideAfterPasting" id="20"/>
                         </connections>
                     </button>
-                    <button toolTip="Hide clipboard automatically after pasting" id="TyO-k8-hDx" userLabel="Paste on selection">
+                    <button toolTip="Paste directly after Selection" id="TyO-k8-hDx" userLabel="Paste on selection">
                         <rect key="frame" x="17" y="196" width="137" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Paste on selection" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="zvX-Sh-Jno">
@@ -82,7 +82,7 @@
                             <font key="font" metaFont="smallSystem"/>
                         </buttonCell>
                         <connections>
-                            <binding destination="17" name="value" keyPath="values.Paste on Selection" id="vlG-kN-eWb"/>
+                            <binding destination="17" name="value" keyPath="values.QSPasteboard Paste on Selection" id="vlG-kN-eWb"/>
                         </connections>
                     </button>
                     <textField hidden="YES" verticalHuggingPriority="750" id="12">
@@ -163,17 +163,6 @@
                                     <string key="NSValueTransformerName">NSNegateBoolean</string>
                                 </dictionary>
                             </binding>
-                        </connections>
-                    </button>
-                    <button toolTip="Paste directly after selecting an item" id="IbY-tZ-Ao7" userLabel="Beep">
-                        <rect key="frame" x="17" y="178" width="137" height="18"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <buttonCell key="cell" type="check" title="Beep on Paste" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="cN2-ot-hfV">
-                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                            <font key="font" metaFont="smallSystem"/>
-                        </buttonCell>
-                        <connections>
-                            <binding destination="17" name="value" keyPath="values.Beep" id="xC4-Rc-pfV"/>
                         </connections>
                     </button>
                 </subviews>


### PR DESCRIPTION
Quicksilver automatically pastes on selection (default). I added a option to decide whether Quicksilver should do that.
Also added an option to toggle the beep, that gets played, when there was an error.

![screen shot 2016-10-29 at 00 57 19](https://cloud.githubusercontent.com/assets/2621491/19824770/ac7ba85a-9d72-11e6-9a57-be8e809e69ee.png)
