### PR TITLE
Bound checks

### DIFF
--- a/QSPasteboardController.m
+++ b/QSPasteboardController.m
@@ -511,8 +511,8 @@
 - (id)selectedObject {
     @synchronized(self.currentArray) {
         NSInteger index = [pasteboardHistoryTable selectedRow];
-        if (index<0) return nil;
-        if (![self.currentArray count]) return nil;
+        if (index < 0 || index >= (NSInteger)self.currentArray.count) return nil;
+
         return [self.currentArray objectAtIndex:index];
     }
 }
@@ -636,13 +636,14 @@
 - (id)tableView:(NSTableView *)aTableView objectValueForTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex {
     //  rowIndex++;
     @synchronized(self.currentArray) {
-        if (rowIndex>((NSInteger)[self.currentArray count] -1) ) {
+        if (rowIndex < 0 || rowIndex >= (NSInteger)self.currentArray.count) {
             return nil;
         }
-        if ([[aTableColumn identifier] isEqualToString:@"object"] && (NSInteger)[self.currentArray count] >rowIndex)
+        if ([[aTableColumn identifier] isEqualToString:@"object"])
             return [self.currentArray objectAtIndex:rowIndex];
+
         if ([[aTableColumn identifier] isEqualToString:@"sequence"]) {
-            if (rowIndex<9) return [NSNumber numberWithInteger:rowIndex+1];
+            if (rowIndex < 9) return [NSNumber numberWithInteger:rowIndex+1];
         }
     }
 
@@ -660,7 +661,7 @@
 }
 - (void)tableView:(NSTableView *)aTableView willDisplayCell:(id)aCell forTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex {
     //NSLog(@"setCell %d", rowIndex);
-    if (rowIndex >= (NSInteger)([self.currentArray count] -1) ) return;
+    if (rowIndex < 0 || rowIndex >= (NSInteger)self.currentArray.count) return;
     if ([[aTableColumn identifier] isEqualToString:@"object"]) {
         [aCell setRepresentedObject:[self.currentArray objectAtIndex:rowIndex]];
 		[aCell setState:NSOffState];

--- a/QSPasteboardController.m
+++ b/QSPasteboardController.m
@@ -372,7 +372,7 @@
     // check the string value of the objects to compare (the object's aren't necessarily the same if one has more pasteboard types
     // (e.g. RTF data) than the other)
     // receiving selection decides whether an existing object on the clipboard should be 'moved up' to the 0th position
-    BOOL recievingSelection = [[[self selectedObject] stringValue] isEqualToString:[newObject stringValue]];
+
     NSIndexSet *objectsToRemove = [pasteboardHistoryArray indexesOfObjectsPassingTest:^BOOL(QSObject *pasteboardObject, NSUInteger idx, BOOL *stop) {
         // if the object (string) is already on the pasteboard
         if([[pasteboardObject stringValue] isEqualToString:[newObject stringValue]]) {
@@ -428,6 +428,8 @@
 
     [pasteboardHistoryTable reloadData];
 
+
+    BOOL recievingSelection = [[[self selectedObject] stringValue] isEqualToString:[newObject stringValue]];
     if (recievingSelection) {
         [pasteboardHistoryTable selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
         [pasteboardHistoryTable scrollRowToVisible:0];

--- a/QSPasteboardController.m
+++ b/QSPasteboardController.m
@@ -428,8 +428,12 @@
 
     [pasteboardHistoryTable reloadData];
 
+    /* Safeguard against weird objects getting in here, like QSNullObject */
+    id obj = self.selectedObject;
+    if (![obj respondsToSelector:@selector(stringValue)])
+        obj = nil;
 
-    BOOL recievingSelection = [[[self selectedObject] stringValue] isEqualToString:[newObject stringValue]];
+    BOOL recievingSelection = [[obj stringValue] isEqualToString:[newObject stringValue]];
     if (recievingSelection) {
         [pasteboardHistoryTable selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
         [pasteboardHistoryTable scrollRowToVisible:0];


### PR DESCRIPTION
Some fix for crashers in the Clipboard plugin.

First commit should fix :
```
Application Specific Information:
*** Terminating app due to uncaught exception 'NSRangeException', reason: '*** -[__NSArrayM objectAtIndex:]: index 10 beyond bounds [0 .. 9]'
abort() called
terminating with uncaught exception of type NSException

Application Specific Backtrace 1:
0   CoreFoundation                      0x00007fff85718452 __exceptionPreprocess + 178
1   libobjc.A.dylib                     0x00007fff8e71473c objc_exception_throw + 48
2   CoreFoundation                      0x00007fff8562f775 -[__NSArrayM objectAtIndex:] + 245
3   Clipboard Plugin                    0x000000010a987d20 Clipboard Plugin + 23840
4   Clipboard Plugin                    0x000000010a987561 Clipboard Plugin + 21857
5   libdispatch.dylib                   0x00007fff889c193d _dispatch_call_block_and_release + 12
6   libdispatch.dylib                   0x00007fff889b640b _dispatch_client_callout + 8
7   libdispatch.dylib                   0x00007fff889bb03b _dispatch_queue_drain + 754
8   libdispatch.dylib                   0x00007fff889c1707 _dispatch_queue_invoke + 549
9   libdispatch.dylib                   0x00007fff889b640b _dispatch_client_callout + 8
10  libdispatch.dylib                   0x00007fff889ba29b _dispatch_root_queue_drain + 1890
11  libdispatch.dylib                   0x00007fff889b9b00 _dispatch_worker_thread3 + 91
12  libsystem_pthread.dylib             0x00007fff855f34de _pthread_wqthread + 1129
13  libsystem_pthread.dylib             0x00007fff855f1341 start_wqthread + 13
```
because there's two "Clipboard Plugin", and `-selectedObject` is the only one with a `objectAtIndex:` call that is called by other methods.

I think that's the most 2nd crash actually, it just confused my stack-parser.