### PR TITLE
Revert some changes from 01ddaa2efad8679ed1a2729c5b320e36584b5160

### DIFF
--- a/QSPasteboardController.m
+++ b/QSPasteboardController.m
@@ -364,7 +364,7 @@
 		return;
 	}
 	// get a new object from the general (system-wide) pasteboard
-    __block QSObject *newObject = [QSObject objectWithPasteboard:pboard];
+	QSObject *newObject = [QSObject objectWithPasteboard:pboard];
 
 	if (!newObject) {
         return;
@@ -374,25 +374,16 @@
 	while ((NSInteger)[pasteboardHistoryArray count] > maxCount) [pasteboardHistoryArray removeLastObject];
 	
 	// Store the most 'rich' (has more data types) version of an object on the pasteboard (e.g. a QSObject with RTF data over just plaintext data)
-	__block BOOL updatePasteboard = NO;
     NSIndexSet *existingObjectIndex = [pasteboardHistoryArray indexesOfObjectsPassingTest:^BOOL(QSObject *pasteboardObject, NSUInteger idx, BOOL *stop) {
         if([[pasteboardObject stringValue] isEqualToString:[newObject stringValue]]) {
 			if ([pasteboardObject dataDictionary].count > [newObject dataDictionary].count) {
-				newObject = pasteboardObject;
-				updatePasteboard = YES;
+					[[newObject dataDictionary] addEntriesFromDictionary:[pasteboardObject dataDictionary]];
 			}
 			*stop = YES;
 			return YES;
         }
         return NO;
     }];
-	if (updatePasteboard) {
-		// also put this item *back* on the pasteboard
-		supressCapture = YES;
-		[newObject putOnPasteboard:[NSPasteboard generalPasteboard]];
-		return;
-	}
-	id selectedObject = [self selectedObject];
 	[pasteboardHistoryArray removeObjectsAtIndexes:existingObjectIndex];
 
 
@@ -433,7 +424,7 @@
 
     supressCapture = NO;
 
-
+	id selectedObject = [self selectedObject];
     [pasteboardHistoryTable reloadData];
 
     /* Safeguard against weird objects getting in here, like QSNullObject */

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.1</string>
+	<string>1.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>15D</string>
+	<string>15F</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2014, QSApp</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Changes with 'rich' data in this commit led to issues copying/pasting data from certain apps (e.g. formulas from Excel). Revert these changes.


I'm surprised this hasn't been brought up anywhere else, but it was driving me mad. I've finally got time to look into this, ultimately I've just reverted the changes for now.

Test:

1. With current plugin/new plugin: copy a cell with a formula in Excel
2. Try and paste the data into another cell.
3. Note that old plugin wouldn't paste any data. Updated code works as expected

